### PR TITLE
Rename `Lock.update()` to `Lock.refresh()` to match `AccessCode`.

### DIFF
--- a/pyschlage/models.py
+++ b/pyschlage/models.py
@@ -195,7 +195,7 @@ class AccessCode(_Mutable):
         return json
 
     def refresh(self):
-        """Refreshes internal state."""
+        """Refreshes the AccessCode state."""
         if self._auth is None:
             raise NotAuthenticatedError
         path = self.request_path(self.device_id, self.access_code_id)
@@ -337,8 +337,8 @@ class Lock(_Mutable):
             firmware_version=json["attributes"]["mainFirmwareVersion"],
         )
 
-    def update(self):
-        """Updates the current device state."""
+    def refresh(self):
+        """Refreshes the Lock state."""
         path = self.request_path(self.device_id)
         self._update_with(self._auth.request("get", path).json())
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -146,14 +146,14 @@ class TestLock:
         assert not lock.is_locked
         assert lock.is_jammed
 
-    def test_update(self):
+    def test_refresh(self):
         auth = mock.Mock()
         lock = pyschlage.Lock.from_json(auth, LOCK_JSON)
         new_json = deepcopy(LOCK_JSON)
         new_json["name"] = "<NAME>"
 
         auth.request.return_value = mock.Mock(json=mock.Mock(return_value=new_json))
-        lock.update()
+        lock.refresh()
 
         auth.request.assert_called_once_with("get", "devices/__device_uuid__")
         assert lock.name == "<NAME>"


### PR DESCRIPTION
This makes the intent of the method clearer and improves consistency between models.