### PR TITLE
Don't error when a lock is unavailable.

### DIFF
--- a/pyschlage/lock.py
+++ b/pyschlage/lock.py
@@ -32,17 +32,17 @@ class Lock(Mutable):
     battery_level: int | None = None
     """The remaining battery level of the lock.
 
-    This is an integer between 0 and 100.
+    This is an integer between 0 and 100 or None if lock is unavailable.
     """
 
-    is_locked: bool = False
-    """Whether the device is currently locked."""
+    is_locked: bool | None = False
+    """Whether the device is currently locked or None if lock is unavailable."""
 
-    is_jammed: bool = False
-    """Whether the lock has identified itself as jammed."""
+    is_jammed: bool | None = False
+    """Whether the lock has identified itself as jammed or None if lock is unavailable."""
 
     firmware_version: str | None = None
-    """The firmware version installed on the lock."""
+    """The firmware version installed on the lock or None if lock is unavailable."""
 
     _cat: str = ""
 
@@ -63,6 +63,11 @@ class Lock(Mutable):
 
         :meta private:
         """
+        is_locked = is_jammed = None
+        if "lockState" in json["attributes"]:
+            is_locked = json["attributes"]["lockState"] == 1
+            is_jammed = json["attributes"]["lockState"] == 2
+
         return cls(
             _auth=auth,
             device_id=json["deviceId"],
@@ -70,8 +75,8 @@ class Lock(Mutable):
             model_name=json["modelName"],
             device_type=json["devicetypeId"],
             battery_level=json["attributes"].get("batteryLevel"),
-            is_locked=json["attributes"]["lockState"] == 1,
-            is_jammed=json["attributes"]["lockState"] == 2,
+            is_locked=is_locked,
+            is_jammed=is_jammed,
             firmware_version=json["attributes"].get("mainFirmwareVersion"),
             _cat=json["CAT"],
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,6 +104,15 @@ def wifi_lock_json(lock_users_json):
 
 
 @fixture
+def wifi_lock_unavailable_json(wifi_lock_json):
+    keep = ("modelName", "serialNumber", "macAddress", "SAT", "CAT")
+    for k in list(wifi_lock_json["attributes"].keys()):
+        if k not in keep:
+            del wifi_lock_json["attributes"][k]
+    return wifi_lock_json
+
+
+@fixture
 def lock_json(wifi_lock_json):
     return wifi_lock_json
 

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -16,24 +16,23 @@ class TestLock:
         assert lock.battery_level == 95
         assert lock.is_locked
         assert lock._cat == "01234"
-        assert not lock.is_jammed
+        assert lock.is_jammed == False
         assert lock.firmware_version == "10.00.00264232"
 
     def test_from_json_is_jammed(self, mock_auth, lock_json):
         lock_json["attributes"]["lockState"] = 2
         lock = Lock.from_json(mock_auth, lock_json)
-        assert not lock.is_locked
+        assert lock.is_locked == False
         assert lock.is_jammed
 
-    def test_from_json_no_battery(self, mock_auth, lock_json):
-        del lock_json["attributes"]["batteryLevel"]
-        lock = Lock.from_json(mock_auth, lock_json)
+    def test_from_json_wifi_lock_unavailable(
+        self, mock_auth, wifi_lock_unavailable_json
+    ):
+        lock = Lock.from_json(mock_auth, wifi_lock_unavailable_json)
         assert lock.battery_level is None
-
-    def test_from_json_no_firmware_version(self, mock_auth, lock_json):
-        del lock_json["attributes"]["mainFirmwareVersion"]
-        lock = Lock.from_json(mock_auth, lock_json)
         assert lock.firmware_version is None
+        assert lock.is_locked is None
+        assert lock.is_jammed is None
 
     def test_refresh(self, mock_auth, lock_json):
         lock = Lock.from_json(mock_auth, lock_json)
@@ -81,7 +80,7 @@ class TestLock:
         mock_auth.request.assert_called_once_with(
             "put", "devices/__wifi_uuid__", json={"attributes": {"lockState": 0}}
         )
-        assert not lock.is_locked
+        assert lock.is_locked == False
 
     def test_lock_ble(self, mock_auth, ble_lock_json):
         lock = Lock.from_json(mock_auth, ble_lock_json)
@@ -117,7 +116,7 @@ class TestLock:
         mock_auth.request.assert_called_once_with(
             "post", "devices/__ble_uuid__/commands", json=command_json
         )
-        assert not lock.is_locked
+        assert lock.is_locked == False
 
     def test_access_codes(self, mock_auth, lock_json, access_code_json):
         lock = Lock.from_json(mock_auth, lock_json)


### PR DESCRIPTION
When a lock is unavailable (e.g. hasn't checked in with the cloud API for a while), there are a few values that are not returned by the API. We need to properly account for this when converting from JSON into our data type.

This helps fix https://github.com/dknowles2/ha-schlage/issues/56