### PR TITLE
Catch and re-raise HTTP errors from the API

### DIFF
--- a/pyschlage/exceptions.py
+++ b/pyschlage/exceptions.py
@@ -6,7 +6,7 @@ class Error(Exception):
 
 
 class NotAuthenticatedError(Error):
-    """Raised when a request is made to an unathenticated object."""
+    """Raised when a request is made to an unauthenticated object."""
 
 
 class NotAuthorizedError(Error):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,9 @@
 from unittest import mock
 
+import pytest
+import requests
+
+import pyschlage
 from pyschlage import auth as _auth
 
 
@@ -29,6 +33,62 @@ def test_request(mock_cognito, mock_srp_auth, mock_request):
     mock_request.assert_called_once_with(
         "get",
         "https://api.allegion.yonomi.cloud/v1/foo/bar",
+        timeout=60,
+        auth=mock_srp_auth.return_value,
+        headers={"X-Api-Key": _auth.API_KEY},
+        baz="bam",
+    )
+
+
+@mock.patch("requests.request", spec=True)
+@mock.patch("pycognito.utils.RequestsSrpAuth", spec=True)
+@mock.patch("pycognito.Cognito")
+def test_request_not_authorized(mock_cognito, mock_srp_auth, mock_request):
+    url = "https://api.allegion.yonomi.cloud/v1/foo/bar"
+    auth = _auth.Auth("__username__", "__password__")
+    mock_resp = mock.create_autospec(requests.Response)
+    mock_resp.raise_for_status.side_effect = requests.HTTPError(
+        f"401 Client Error: Unauthorized for url: {url}"
+    )
+    mock_resp.status_code = 401
+    mock_resp.reason = "Unauthorized"
+    mock_resp.json.side_effect = lambda: {"message": "Unauthorized"}
+    mock_request.return_value = mock_resp
+
+    with pytest.raises(pyschlage.exceptions.NotAuthorizedError):
+        auth.request("get", "/foo/bar", baz="bam")
+
+    mock_request.assert_called_once_with(
+        "get",
+        url,
+        timeout=60,
+        auth=mock_srp_auth.return_value,
+        headers={"X-Api-Key": _auth.API_KEY},
+        baz="bam",
+    )
+
+
+@mock.patch("requests.request", spec=True)
+@mock.patch("pycognito.utils.RequestsSrpAuth", spec=True)
+@mock.patch("pycognito.Cognito")
+def test_request_unknown_error(mock_cognito, mock_srp_auth, mock_request):
+    url = "https://api.allegion.yonomi.cloud/v1/foo/bar"
+    auth = _auth.Auth("__username__", "__password__")
+    mock_resp = mock.create_autospec(requests.Response)
+    mock_resp.raise_for_status.side_effect = requests.HTTPError(
+        f"500 Server Error: Internal for url: {url}"
+    )
+    mock_resp.status_code = 500
+    mock_resp.reason = "Internal"
+    mock_resp.json.side_effect = requests.JSONDecodeError("msg", "doc", 1)
+    mock_request.return_value = mock_resp
+
+    with pytest.raises(pyschlage.exceptions.UnknownError):
+        auth.request("get", "/foo/bar", baz="bam")
+
+    mock_request.assert_called_once_with(
+        "get",
+        url,
         timeout=60,
         auth=mock_srp_auth.return_value,
         headers={"X-Api-Key": _auth.API_KEY},


### PR DESCRIPTION
This should help address https://github.com/dknowles2/ha-schlage/issues/45 where we occasionally see our credentials rejected and the API return JSON that's not usable by the library.