### PR TITLE
Classify Encode Lever locks as WiFi locks

### DIFF
--- a/pyschlage/lock.py
+++ b/pyschlage/lock.py
@@ -86,9 +86,10 @@ class Lock(Mutable):
         )
 
     def _is_wifi_lock(self) -> bool:
-        return self.device_type.startswith("be489") or self.device_type.startswith(
-            "be499"
-        )
+        for prefix in ("be489", "be499", "fe789"):
+            if self.device_type.startswith(prefix):
+                return True
+        return False
 
     def refresh(self):
         """Refreshes the Lock state.


### PR DESCRIPTION
Multiple people have reported Encode Lever locks not working in https://github.com/dknowles2/ha-schlage/issues/88. I think this is because they are classified as "WiFi locks" to get the right API endpoint for lock/unlock operations. 