### PR TITLE
Fix access code support

### DIFF
--- a/pyschlage/auth.py
+++ b/pyschlage/auth.py
@@ -30,7 +30,7 @@ USER_POOL_ID = USER_POOL_REGION + "_2zhrVs9d4"
 
 def _translate_auth_errors(
     # pylint: disable=invalid-name
-    fn: Callable[..., requests.Response]
+    fn: Callable[..., requests.Response],
     # pylint: enable=invalid-name
 ) -> Callable[..., requests.Response]:
     @wraps(fn)
@@ -50,7 +50,7 @@ def _translate_auth_errors(
 
 def _translate_http_errors(
     # pylint: disable=invalid-name
-    fn: Callable[..., requests.Response]
+    fn: Callable[..., requests.Response],
     # pylint: enable=invalid-name
 ) -> Callable[..., requests.Response]:
     @wraps(fn)

--- a/pyschlage/code.py
+++ b/pyschlage/code.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import astuple, dataclass, field
 from datetime import datetime
+from typing import Any
 
 from .common import Mutable
 from .exceptions import NotAuthenticatedError
@@ -163,6 +164,8 @@ class AccessCode(Mutable):
     access_code_id: str = field(default="", repr=False)
     """Unique identifier for the access code."""
 
+    _json: dict[Any, Any] = field(default_factory=dict, repr=False)
+
     @staticmethod
     def request_path(device_id: str, access_code_id: str | None = None) -> str:
         """Returns the request path for an AccessCode.
@@ -188,6 +191,7 @@ class AccessCode(Mutable):
 
         return AccessCode(
             _auth=auth,
+            _json=json,
             device_id=device_id,
             access_code_id=json["accesscodeId"],
             name=json["friendlyName"],

--- a/pyschlage/code.py
+++ b/pyschlage/code.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import astuple, dataclass, field
-from datetime import UTC, datetime, timezone
+from datetime import datetime
 
 from .common import Mutable
 from .exceptions import NotAuthenticatedError
@@ -34,12 +34,8 @@ class TemporarySchedule:
         :meta private:
         """
         return TemporarySchedule(
-            start=datetime.fromtimestamp(json["activationSecs"], UTC).replace(
-                tzinfo=None
-            ),
-            end=datetime.fromtimestamp(json["expirationSecs"], UTC).replace(
-                tzinfo=None
-            ),
+            start=datetime.fromtimestamp(json["activationSecs"]),
+            end=datetime.fromtimestamp(json["expirationSecs"]),
         )
 
     def to_json(self) -> dict:
@@ -48,8 +44,8 @@ class TemporarySchedule:
         :meta private:
         """
         return {
-            "activationSecs": int(self.start.replace(tzinfo=timezone.utc).timestamp()),
-            "expirationSecs": int(self.end.replace(tzinfo=timezone.utc).timestamp()),
+            "activationSecs": int(self.start.timestamp()),
+            "expirationSecs": int(self.end.timestamp()),
         }
 
 

--- a/pyschlage/common.py
+++ b/pyschlage/common.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass, field, fields
+from datetime import UTC, datetime
 from threading import Lock as Mutex
+from time import mktime
 from typing import Any
 
 from .auth import Auth
@@ -31,6 +33,21 @@ class Mutable:
         with self._mu:
             for f in fields(new_obj):
                 setattr(self, f.name, getattr(new_obj, f.name))
+
+
+def utc2local(utc: datetime) -> datetime:
+    """Converts a UTC datetime to localtime."""
+    epoch = mktime(utc.timetuple())
+    offset = datetime.fromtimestamp(epoch) - datetime.fromtimestamp(epoch, UTC).replace(
+        tzinfo=None
+    )
+    return (utc + offset).replace(tzinfo=None)
+
+
+def fromisoformat(dt: str) -> datetime:
+    """Converts an ISO formatted datetime into a datetime object."""
+    # datetime.fromisoformat() doesn't like fractional seconds with a "Z" suffix.
+    return datetime.fromisoformat(dt.rstrip("Z") + "+00:00")
 
 
 def redact(json: dict[Any, Any], *, allowed: list[str]) -> dict[str, Any]:

--- a/pyschlage/device.py
+++ b/pyschlage/device.py
@@ -1,6 +1,12 @@
 """Schlage devices."""
 
+from dataclasses import dataclass
 from enum import Enum
+
+from requests import Response
+
+from .common import Mutable
+from .exceptions import NotAuthenticatedError
 
 
 class DeviceType(str, Enum):
@@ -26,3 +32,36 @@ class DeviceType(str, Enum):
     JACKALOPE_MCKINLEY_WIFI = "be499wifi2"
     JACKALOPE_WIFI = "be499wifi"
     SENSE = "be479"
+
+
+@dataclass
+class Device(Mutable):
+    """Base class for Schlage devices."""
+
+    device_id: str = ""
+    """Schlage-generated unique device identifier."""
+
+    device_type: str = ""
+    """The device type of the lock.
+
+    See |DeviceType| for currently known types.
+    """
+
+    @staticmethod
+    def request_path(device_id: str | None = None) -> str:
+        """Returns the request path for a Lock.
+
+        :meta private:
+        """
+        path = "devices"
+        if device_id:
+            path = f"{path}/{device_id}"
+        return path
+
+    def send_command(self, command: str, data=dict) -> Response:
+        """Sends a command to the device."""
+        if not self._auth:
+            raise NotAuthenticatedError
+        path = f"{self.request_path(self.device_id)}/commands"
+        json = {"data": data, "name": command}
+        return self._auth.request("post", path, json=json)

--- a/pyschlage/lock.py
+++ b/pyschlage/lock.py
@@ -366,6 +366,10 @@ class Lock(Mutable):
         resp = self._auth.request("post", path, json=code.to_json())
         code._auth = self._auth
         code._update_with(resp.json(), self.device_id)
+        code._json = code.to_json()
+        if self.access_codes is None:
+            self.access_codes = {}
+        self.access_codes[code.access_code_id] = code
 
     def set_beeper(self, enabled: bool):
         """Sets the beeper_enabled setting."""

--- a/pyschlage/lock.py
+++ b/pyschlage/lock.py
@@ -3,15 +3,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
-
-from requests import Response
+from typing import Any, Iterable
 
 from .auth import Auth
 from .code import AccessCode
-from .common import Mutable, redact
+from .common import redact
+from .device import Device
 from .exceptions import NotAuthenticatedError
 from .log import LockLog
+from .notification import ON_UNLOCK_ACTION, Notification
 from .user import User
 
 
@@ -41,23 +41,14 @@ class LockStateMetadata:
 
 
 @dataclass
-class Lock(Mutable):
+class Lock(Device):
     """A Schlage WiFi lock."""
-
-    device_id: str = ""
-    """Schlage-generated unique device identifier."""
 
     name: str = ""
     """User-specified name of the lock."""
 
     model_name: str = ""
     """The model name of the lock."""
-
-    device_type: str = ""
-    """The device type of the lock.
-
-    Also see known device types in device.py.
-    """
 
     connected: bool = False
     """Whether the lock is connected to WiFi."""
@@ -104,17 +95,6 @@ class Lock(Mutable):
     _cat: str = field(default="", repr=False)
 
     _json: dict[Any, Any] = field(default_factory=dict, repr=False)
-
-    @staticmethod
-    def request_path(device_id: str | None = None) -> str:
-        """Returns the request path for a Lock.
-
-        :meta private:
-        """
-        path = "devices"
-        if device_id:
-            path = f"{path}/{device_id}"
-        return path
 
     @classmethod
     def from_json(cls, auth: Auth, json: dict) -> Lock:
@@ -230,13 +210,6 @@ class Lock(Mutable):
         resp = self._auth.request("put", path, json=json)
         self._update_with(resp.json())
 
-    def _send_command(self, command: str, data=dict) -> Response:
-        if not self._auth:
-            raise NotAuthenticatedError
-        path = f"{self.request_path(self.device_id)}/commands"
-        json = {"data": data, "name": command}
-        return self._auth.request("post", path, json=json)
-
     def _toggle(self, lock_state: int):
         if not self._auth:
             raise NotAuthenticatedError
@@ -249,7 +222,7 @@ class Lock(Mutable):
                 "state": lock_state,
                 "userId": self._auth.user_id,
             }
-            self._send_command("changelockstate", data)
+            self.send_command("changelockstate", data)
             self.is_locked = lock_state == 1
             self.is_jammed = False
 
@@ -341,18 +314,54 @@ class Lock(Mutable):
     def refresh_access_codes(self) -> None:
         """Fetches access codes for this lock.
 
-        :rtype: list[pyschlage.code.AccessCode]
         :raise pyschlage.exceptions.NotAuthorizedError: When authentication fails.
         :raise pyschlage.exceptions.UnknownError: On other errors.
         """
+        self.access_codes = {}
+        for code in self._get_access_codes():
+            assert code.access_code_id is not None
+            self.access_codes[code.access_code_id] = code
+
+    def _get_access_codes(self) -> Iterable[AccessCode]:
         if not self._auth:
             raise NotAuthenticatedError
+
+        # Access Codes can be configured to notify the user on use via the app.
+        # To make this work, a Notification must also be added, with its ID set
+        # to "{user_id}_{access_code_id}". If notifications are disabled for
+        # the access code, the Notification's |active| attribute is set to
+        # False. In some cases, there may also just not be a Notification
+        # added if notifications are disabled.
+        notifications: dict[str, Notification] = {}
+        user_id_len = len(self._auth.user_id)
+        for notification in self._get_notifications():
+            if notification.notification_type == ON_UNLOCK_ACTION:
+                if not notification.notification_id.startswith(self._auth.user_id):
+                    # This shouldn't happen, but ignore it just in case.
+                    continue
+                access_code_id = notification.notification_id[user_id_len + 1 :]
+                notifications[access_code_id] = notification
+        print("x" * 80)
+        print(notifications)
         path = AccessCode.request_path(self.device_id)
         resp = self._auth.request("get", path)
-        self.access_codes = {}
         for code_json in resp.json():
-            code = AccessCode.from_json(self._auth, code_json, self.device_id)
-            self.access_codes[code.access_code_id] = code
+            access_code = AccessCode.from_json(self._auth, self, code_json)
+            access_code.device_id = self.device_id
+            if access_code.access_code_id in notifications:
+                access_code._notification = notification
+            yield access_code
+
+    def _get_notifications(self) -> Iterable[Notification]:
+        if not self._auth:
+            raise NotAuthenticatedError
+        path = Notification.request_path()
+        params = {"deviceId": self.device_id}
+        resp = self._auth.request("get", path, params=params)
+        for notification_json in resp.json():
+            notification = Notification.from_json(self._auth, self, notification_json)
+            notification.device_type = self.device_type
+            yield notification
 
     def add_access_code(self, code: AccessCode):
         """Adds an access code to the lock.
@@ -362,15 +371,9 @@ class Lock(Mutable):
         :raise pyschlage.exceptions.NotAuthorizedError: When authentication fails.
         :raise pyschlage.exceptions.UnknownError: On other errors.
         """
-        if not self._auth:
-            raise NotAuthenticatedError
-        resp = self._send_command("addaccesscode", code.to_json())
         code._auth = self._auth
-        code._update_with(resp.json(), self.device_id)
-        code._json = code.to_json()
-        if self.access_codes is None:
-            self.access_codes = {}
-        self.access_codes[code.access_code_id] = code
+        code._device = self
+        code.save()
 
     def set_beeper(self, enabled: bool):
         """Sets the beeper_enabled setting."""

--- a/pyschlage/notification.py
+++ b/pyschlage/notification.py
@@ -1,0 +1,102 @@
+"""Notifications for Schlage WiFi devices."""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from .auth import Auth
+from .common import Mutable, fromisoformat
+from .device import Device
+from .exceptions import NotAuthenticatedError
+
+ON_ALARM = "onalarmstate"
+ON_BATTERY_LOW = "onbatterylowstate"
+ON_LOCKED = "onstatelocked"
+OFFLINE_24_HOURS = "offline24hours"
+ON_UNLOCK_ACTION = "onunlockstateaction"
+ON_UNLOCKED = "onstateunlocked"
+UNKNOWN = "__unknown__"
+
+
+@dataclass
+class Notification(Mutable):
+    """A Schlage WiFi lock notification."""
+
+    notification_id: str = ""
+    user_id: str | None = None
+    device_id: str | None = None
+    device_type: str | None = None
+    notification_type: str = UNKNOWN
+    active: bool = False
+    filter_value: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    _device: Device | None = field(default=None, repr=False)
+    _json: dict[str, Any] = field(default_factory=dict, repr=False)
+
+    @staticmethod
+    def request_path(notification_id: str | None = None) -> str:
+        """Returns the request path for the Notification.
+
+        :meta private:
+        """
+        path = "notifications"
+        if notification_id is not None:
+            path = f"{path}/{notification_id}"
+        return path
+
+    @classmethod
+    def from_json(
+        cls, auth: Auth, device: Device, json: dict[str, Any]
+    ) -> "Notification":
+        return Notification(
+            _auth=auth,
+            _json=json,
+            _device=device,
+            notification_id=json["notificationId"],
+            user_id=json["userId"],
+            device_id=json["deviceId"],
+            notification_type=json["notificationDefinitionId"],
+            active=json["active"],
+            filter_value=json.get("filterValue", None),
+            created_at=fromisoformat(json["createdAt"]),
+            updated_at=fromisoformat(json["updatedAt"]),
+        )
+
+    def to_json(self) -> dict[str, Any]:
+        """Returns a JSON dict with this Notification's mutable properties."""
+        json: dict[str, Any] = {
+            "notificationId": self.notification_id,
+            "userId": self.user_id,
+            "deviceId": self.device_id,
+            "devicetypeId": self.device_type,
+            "notificationDefinitionId": self.notification_type,
+            "active": self.active,
+        }
+        if self.filter_value is not None:
+            json["filterValue"] = self.filter_value
+        return json
+
+    def save(self, device: Device | None = None):
+        """Saves the Notification."""
+        if not self._auth:
+            raise NotAuthenticatedError
+        if device:
+            self._device = device
+        assert self._device is not None
+        method = "put" if self.created_at else "post"
+        path = self.request_path(self.notification_id)
+        resp = self._auth.request(method, path, self.to_json())
+        self._update_with(self._device, resp.json())
+
+    def delete(self):
+        """Deletes the notification."""
+        if not self._auth:
+            raise NotAuthenticatedError
+        path = self.request_path(self.notification_id)
+        self._auth.request("delete", path)
+        self._auth = None
+        self._json = {}
+        self._device = None
+        self.notification_id = None
+        self.active = False

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,14 +1,21 @@
 from __future__ import annotations
 
+from typing import Any
 from unittest import mock
 
 from pyschlage import api
 
 
-def test_locks(mock_auth: mock.Mock, lock_json: dict, access_code_json: dict) -> None:
+def test_locks(
+    mock_auth: mock.Mock,
+    lock_json: dict[str, Any],
+    access_code_json: dict[str, Any],
+    notification_json: dict[str, Any],
+) -> None:
     schlage = api.Schlage(mock_auth)
     mock_auth.request.side_effect = [
         mock.Mock(json=mock.Mock(return_value=[lock_json])),
+        mock.Mock(json=mock.Mock(return_value=[notification_json])),
         mock.Mock(json=mock.Mock(return_value=[access_code_json])),
     ]
     locks = schlage.locks()
@@ -16,6 +23,9 @@ def test_locks(mock_auth: mock.Mock, lock_json: dict, access_code_json: dict) ->
     mock_auth.request.assert_has_calls(
         [
             mock.call("get", "devices", params={"archetype": "lock"}),
+            mock.call(
+                "get", "notifications", params={"deviceId": lock_json["deviceId"]}
+            ),
             mock.call("get", "devices/__wifi_uuid__/storage/accesscode"),
         ]
     )

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -1,50 +1,54 @@
 from copy import deepcopy
 from datetime import datetime
-from unittest import mock
+from typing import Any
+from unittest.mock import Mock, create_autospec, patch
 
-from pyschlage.auth import Auth
 from pyschlage.code import AccessCode, DaysOfWeek, RecurringSchedule, TemporarySchedule
+from pyschlage.device import Device
+from pyschlage.notification import Notification
 
 
 class TestAccessCode:
-    def test_to_from_json(self, access_code_json):
-        auth = mock.create_autospec(Auth, spec_set=True)
-        device_id = "__device_uuid__"
+    def test_to_from_json(
+        self, mock_auth: Mock, access_code_json: dict[str, Any], wifi_device: Device
+    ):
         access_code_id = "__access_code_uuid__"
         code = AccessCode(
-            _auth=auth,
+            _auth=mock_auth,
+            _device=wifi_device,
             _json=access_code_json,
             name="Friendly name",
             code="0123",
             schedule=None,
-            device_id=device_id,
+            device_id=wifi_device.device_id,
             access_code_id=access_code_id,
         )
-        assert AccessCode.from_json(auth, access_code_json, device_id) == code
+        assert AccessCode.from_json(mock_auth, wifi_device, access_code_json) == code
         assert code.to_json() == access_code_json
 
-    def test_to_from_json_recurring_schedule(self, access_code_json):
-        auth = mock.create_autospec(Auth, spec_set=True)
-        device_id = "__device_uuid__"
+    def test_to_from_json_recurring_schedule(
+        self, mock_auth: Mock, access_code_json: dict[str, Any], wifi_device: Device
+    ):
         access_code_id = "__access_code_uuid__"
         sched = RecurringSchedule(days_of_week=DaysOfWeek(mon=False))
         json = deepcopy(access_code_json)
         json["schedule1"] = sched.to_json()
         code = AccessCode(
-            _auth=auth,
+            _auth=mock_auth,
             _json=json,
+            _device=wifi_device,
             name="Friendly name",
             code="0123",
             schedule=sched,
-            device_id=device_id,
+            device_id=wifi_device.device_id,
             access_code_id=access_code_id,
         )
-        assert AccessCode.from_json(auth, json, device_id) == code
+        assert AccessCode.from_json(mock_auth, wifi_device, json) == code
         assert code.to_json() == json
 
-    def test_to_from_json_temporary_schedule(self, access_code_json):
-        auth = mock.create_autospec(Auth, spec_set=True)
-        device_id = "__device_uuid__"
+    def test_to_from_json_temporary_schedule(
+        self, mock_auth: Mock, access_code_json: dict[str, Any], wifi_device: Device
+    ):
         access_code_id = "__access_code_uuid__"
         sched = TemporarySchedule(
             start=datetime(2022, 12, 25, 8, 30, 0),
@@ -54,67 +58,58 @@ class TestAccessCode:
         json["activationSecs"] = 1671957000
         json["expirationSecs"] = 1671958800
         code = AccessCode(
-            _auth=auth,
+            _auth=mock_auth,
             _json=json,
+            _device=wifi_device,
             name="Friendly name",
             code="0123",
             schedule=sched,
-            device_id=device_id,
+            device_id=wifi_device.device_id,
             access_code_id=access_code_id,
         )
-        assert AccessCode.from_json(auth, json, device_id) == code
+        assert AccessCode.from_json(mock_auth, wifi_device, json) == code
         assert code.to_json() == json
 
-    def test_refresh(self, access_code_json):
-        auth = mock.create_autospec(Auth, spec_set=True)
-        code = AccessCode.from_json(auth, access_code_json, "__device_uuid__")
-        new_json = deepcopy(access_code_json)
-        new_json["accessCode"] = 1122
-
-        auth.request.return_value = mock.Mock(json=mock.Mock(return_value=new_json))
-        code.refresh()
-
-        auth.request.assert_called_once_with(
-            "get", "devices/__device_uuid__/storage/accesscode/__access_code_uuid__"
-        )
-        assert code.code == "1122"
-
-    def test_save(self, access_code_json):
-        auth = mock.create_autospec(Auth, spec_set=True)
-        code = AccessCode.from_json(auth, access_code_json, "__device_uuid__")
-        code.code = 1122
+    def test_save(
+        self,
+        mock_auth: Mock,
+        access_code_json: dict[str, Any],
+    ):
+        mock_device = create_autospec(Device, spec_set=True, device_id="__wifi_uuid__")
+        code = AccessCode.from_json(mock_auth, mock_device, access_code_json)
+        code.code = "1122"
         old_json = code.to_json()
 
         new_json = deepcopy(access_code_json)
-        new_json["accessCode"] = 1122
+        new_json["accessCode"] = "1122"
         # Simulate another change that happened out of band.
         new_json["friendlyName"] = "New name"
 
-        auth.request.return_value = mock.Mock(json=mock.Mock(return_value=new_json))
-        code.save()
-
-        auth.request.assert_called_once_with(
-            "post",
-            "devices/__device_uuid__/commands",
-            json={"data": old_json, "name": "updateaccesscode"},
-        )
+        with patch(
+            "pyschlage.code.Notification", autospec=True
+        ) as mock_notification_cls:
+            mock_notification = create_autospec(Notification, spec_set=True)
+            mock_notification_cls.return_value = mock_notification
+            mock_device.send_command.return_value = Mock(
+                json=Mock(return_value=new_json)
+            )
+            code.save()
+            mock_notification.save.assert_called_once_with(mock_device)
+            mock_device.send_command.assert_called_once_with(
+                "updateaccesscode", old_json
+            )
         assert code.code == "1122"
         # Ensure the name was updated.
         assert code.name == "New name"
 
-    def test_delete(self, access_code_json):
-        auth = mock.create_autospec(Auth, spec_set=True)
-        code = AccessCode.from_json(auth, access_code_json, "__device_uuid__")
-        auth.request.return_value = mock.Mock()
+    def test_delete(self, mock_auth: Mock, access_code_json: dict[str, Any]):
+        mock_device = create_autospec(Device, spec_set=True, device_id="__wifi_uuid__")
+        code = AccessCode.from_json(mock_auth, mock_device, access_code_json)
+        mock_auth.request.return_value = Mock()
         json = code.to_json()
         code.delete()
-        auth.request.assert_called_once_with(
-            "post",
-            "devices/__device_uuid__/commands",
-            json={"data": json, "name": "deleteaccesscode"},
-        )
+        mock_device.send_command.assert_called_once_with("deleteaccesscode", json)
         assert code._auth is None
         assert code._json == {}
         assert code.access_code_id is None
-        assert code.device_id is None
         assert code.disabled

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -13,6 +13,7 @@ class TestAccessCode:
         access_code_id = "__access_code_uuid__"
         code = AccessCode(
             _auth=auth,
+            _json=access_code_json,
             name="Friendly name",
             code="0123",
             schedule=None,
@@ -35,6 +36,7 @@ class TestAccessCode:
         json["schedule1"] = sched.to_json()
         code = AccessCode(
             _auth=auth,
+            _json=json,
             name="Friendly name",
             code="0123",
             schedule=sched,
@@ -60,6 +62,7 @@ class TestAccessCode:
         json["expirationSecs"] = 1671958800
         code = AccessCode(
             _auth=auth,
+            _json=json,
             name="Friendly name",
             code="0123",
             schedule=sched,

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -256,8 +256,8 @@ class TestLock:
 
         mock_auth.request.assert_called_once_with(
             "post",
-            "devices/__wifi_uuid__/storage/accesscode",
-            json=json,
+            "devices/__wifi_uuid__/commands",
+            json={"data": json, "name": "addaccesscode"},
         )
         assert code._auth == mock_auth
         assert code.device_id == lock.device_id

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -1,0 +1,24 @@
+from datetime import UTC, datetime
+from unittest.mock import Mock
+
+from pyschlage.lock import Lock
+from pyschlage.notification import Notification
+
+
+def test_from_json(mock_auth: Mock, wifi_lock: Lock):
+    json = {
+        "active": False,
+        "createdAt": "2020-04-05T21:53:11.438Z",
+        "description": "manages lock/unlock notifications",
+        "deviceId": "__device_id__",
+        "name": "lock notification",
+        "notificationDefinitionId": "onstatelocked",
+        "notificationId": "__notification_id__",
+        "updatedAt": "2020-04-06T18:19:18.402Z",
+        "userId": "eae7b073-de92-4c6c-9b1a-25aa960a36f9",
+    }
+    notification = Notification.from_json(mock_auth, wifi_lock, json)
+    assert not notification.active
+    assert notification.created_at == datetime(
+        2020, 4, 5, 21, 53, 11, 438000, tzinfo=UTC
+    )


### PR DESCRIPTION
This fixes support for access codes, based on insights from https://github.com/dknowles2/pyschlage/issues/56

* Uses the correct API endpoint for managing access codes
* Introduces a `Notification` type which is necessary when `notify_on_use` is `True`
* Cleans up some code

There's still more cleanup that can be done here, and there are some missing tests that I'd like to add, but I've done a small amount of manual testing so I think it should be fairly complete.

h/t @robnewton for the sleuthing of the access code protocol!