### PR TITLE
Don't throw an error if CAT isn't present

### DIFF
--- a/pyschlage/lock.py
+++ b/pyschlage/lock.py
@@ -136,7 +136,7 @@ class Lock(Device):
             firmware_version=attributes.get("mainFirmwareVersion"),
             mac_address=attributes.get("macAddress"),
             users=users,
-            _cat=json["CAT"],
+            _cat=json.get("CAT", ""),
             _json=json,
         )
 

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -35,6 +35,13 @@ class TestLock:
             "foo-bar-uuid": User("Foo Bar", "foo@bar.xyz", "foo-bar-uuid"),
         }
 
+    def test_from_json_cat_optional(
+        self, mock_auth: Mock, lock_json: dict[Any, Any]
+    ) -> None:
+        lock_json.pop("CAT", None)
+        lock = Lock.from_json(mock_auth, lock_json)
+        assert lock._cat == ""
+
     def test_from_json_no_connected(
         self, mock_auth: Mock, lock_json: dict[Any, Any]
     ) -> None:


### PR DESCRIPTION
As reported in https://github.com/home-assistant/core/issues/123556