### PR TITLE
Update `set_auto_lock_time` docstring

### DIFF
--- a/pyschlage/lock.py
+++ b/pyschlage/lock.py
@@ -382,7 +382,8 @@ class Lock(Device):
         self._put_attributes({"lockAndLeaveEnabled": 1 if enabled else 0})
 
     def set_auto_lock_time(self, auto_lock_time: int):
-        """Sets the auto_lock_time setting."""
+        """Sets the auto_lock_time setting. Setting it to `0` turns off the
+        auto-lock feature."""
         if auto_lock_time not in (0, 15, 30, 60, 120, 240, 300):
             raise ValueError(
                 "auto_lock_time must be one of: (0, 15, 30, 60, 120, 240, 300)"


### PR DESCRIPTION
This makes it more clear that `0` disables the auto-lock feature