### PR TITLE
Use SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors         = [
 dependencies    = ["pycognito", "requests"]
 requires-python = ">=3.12"
 dynamic         = ["readme", "version"]
-license         = {text = "Apache License 2.0"}
+license         = {text = "Apache-2.0"}
 keywords        = ["schlage", "api", "iot"]
 classifiers     = [
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Use official SPDX license identifier as recommended by [PEP 639](https://peps.python.org/pep-0639/).
https://spdx.org/licenses/Apache-2.0.html