### PR TITLE
Don't load access codes when reading locks unless requested

### DIFF
--- a/pyschlage/api.py
+++ b/pyschlage/api.py
@@ -18,9 +18,10 @@ class Schlage:
         """
         self._auth = auth
 
-    def locks(self) -> list[Lock]:
+    def locks(self, include_access_codes: bool = False) -> list[Lock]:
         """Retrieves all locks associated with this account.
 
+        :param include_access_codes: Whether to also refresh access codes.
         :rtype: list[Lock]
         :raise pyschlage.exceptions.NotAuthorizedError: When authentication fails.
         :raise pyschlage.exceptions.UnknownError: On other errors.
@@ -30,7 +31,8 @@ class Schlage:
         locks = []
         for lock_json in response.json():
             lock = Lock.from_json(self._auth, lock_json)
-            lock.refresh_access_codes()
+            if include_access_codes:
+                lock.refresh_access_codes()
             locks.append(lock)
         return locks
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,7 +6,17 @@ from unittest import mock
 from pyschlage import api
 
 
-def test_locks(
+def test_locks(mock_auth: mock.Mock, lock_json: dict[str, Any]) -> None:
+    schlage = api.Schlage(mock_auth)
+    mock_auth.request.return_value = mock.Mock(json=mock.Mock(return_value=[lock_json]))
+    locks = schlage.locks()
+    assert len(locks) == 1
+    mock_auth.request.assert_called_once_with(
+        "get", "devices", params={"archetype": "lock"}
+    )
+
+
+def test_locks_with_access_codes(
     mock_auth: mock.Mock,
     lock_json: dict[str, Any],
     access_code_json: dict[str, Any],
@@ -18,7 +28,7 @@ def test_locks(
         mock.Mock(json=mock.Mock(return_value=[notification_json])),
         mock.Mock(json=mock.Mock(return_value=[access_code_json])),
     ]
-    locks = schlage.locks()
+    locks = schlage.locks(include_access_codes=True)
     assert len(locks) == 1
     mock_auth.request.assert_has_calls(
         [


### PR DESCRIPTION
Missed this in #278

This should hopefully address https://github.com/home-assistant/core/issues/137366 (for real this time)