### PR TITLE
Add Support for Recurring Schedule with Multiple Schedules

### DIFF
--- a/pyschlage/code.py
+++ b/pyschlage/code.py
@@ -22,7 +22,14 @@ _ALL_DAYS = "7F"
 
 @dataclass
 class MultiRecurringSchedule:
-    schedules: list[RecurringSchedule]
+    """A schedule consisting of at most two recurring schedules."""
+
+    schedule1: RecurringSchedule | None
+    schedule2: RecurringSchedule | None
+
+    def __post_init__(self):
+        if self.schedule1 is None and self.schedule2 is not None:
+            raise ValueError("schedule1 must be set for schedule2 to be settable.")
 
 @dataclass
 class TemporarySchedule:
@@ -200,14 +207,10 @@ class AccessCode(Mutable):
         schedule: MultiRecurringSchedule | TemporarySchedule | RecurringSchedule | None = None
         if json["activationSecs"] == _MIN_TIME and json["expirationSecs"] == _MAX_TIME:
             if "schedule2" in json:
-                schedules = []
-                # Using a for-loop rather than list comprehension as the default
-                # python type inference on filtering results in None being valid
-                for schedule_json in [json["schedule1"], json["schedule2"]]:
-                    sub_schedule = RecurringSchedule.from_json(schedule_json)
-                    if sub_schedule is not None:
-                        schedules.append(sub_schedule)
-                schedule = MultiRecurringSchedule(schedules)
+                schedule = MultiRecurringSchedule(
+                    RecurringSchedule.from_json(json["schedule1"]),
+                    RecurringSchedule.from_json(json["schedule2"])
+                )
             else:
                 schedule = RecurringSchedule.from_json(json["schedule1"])
         else:
@@ -246,8 +249,10 @@ class AccessCode(Mutable):
         if self.access_code_id:
             json["accesscodeId"] = self.access_code_id
         if isinstance(self.schedule, MultiRecurringSchedule):
-            json["schedule1"] = self.schedule.schedules[0].to_json()
-            json["schedule2"] = self.schedule.schedules[1].to_json()
+            if self.schedule.schedule1 is not None:
+                json["schedule1"] = self.schedule.schedule1.to_json()
+            if self.schedule.schedule2 is not None:
+                json["schedule2"] = self.schedule.schedule2.to_json()
         elif isinstance(self.schedule, RecurringSchedule):
             json["schedule1"] = self.schedule.to_json()
         elif self.schedule is not None:

--- a/pyschlage/code.py
+++ b/pyschlage/code.py
@@ -201,7 +201,8 @@ class AccessCode(Mutable):
         if json["activationSecs"] == _MIN_TIME and json["expirationSecs"] == _MAX_TIME:
             if "schedule2" in json:
                 schedules = []
-                #
+                # Using a for-loop rather than list comprehension as the default
+                # python type inference on filtering results in None being valid
                 for schedule_json in [json["schedule1"], json["schedule2"]]:
                     sub_schedule = RecurringSchedule.from_json(schedule_json)
                     if sub_schedule is not None:

--- a/pyschlage/code.py
+++ b/pyschlage/code.py
@@ -21,7 +21,7 @@ _MAX_MINUTE = 59
 _ALL_DAYS = "7F"
 
 @dataclass
-class MultiSchedule:
+class MultiRecurringSchedule:
     schedules: list[RecurringSchedule]
 
 @dataclass
@@ -155,7 +155,7 @@ class AccessCode(Mutable):
     code: str = ""
     """The access code."""
 
-    schedule: MultiSchedule | TemporarySchedule | RecurringSchedule | None = None
+    schedule: MultiRecurringSchedule | TemporarySchedule | RecurringSchedule | None = None
     """Optional schedule at which the code is enabled."""
 
     notify_on_use: bool = False
@@ -197,7 +197,7 @@ class AccessCode(Mutable):
 
         :meta private:
         """
-        schedule: MultiSchedule | TemporarySchedule | RecurringSchedule | None = None
+        schedule: MultiRecurringSchedule | TemporarySchedule | RecurringSchedule | None = None
         if json["activationSecs"] == _MIN_TIME and json["expirationSecs"] == _MAX_TIME:
             if "schedule2" in json:
                 schedules = []
@@ -206,7 +206,7 @@ class AccessCode(Mutable):
                     sub_schedule = RecurringSchedule.from_json(schedule_json)
                     if sub_schedule is not None:
                         schedules.append(sub_schedule)
-                schedule = MultiSchedule(schedules)
+                schedule = MultiRecurringSchedule(schedules)
             else:
                 schedule = RecurringSchedule.from_json(json["schedule1"])
         else:
@@ -244,7 +244,7 @@ class AccessCode(Mutable):
         }
         if self.access_code_id:
             json["accesscodeId"] = self.access_code_id
-        if isinstance(self.schedule, MultiSchedule):
+        if isinstance(self.schedule, MultiRecurringSchedule):
             json["schedule1"] = self.schedule.schedules[0].to_json()
             json["schedule2"] = self.schedule.schedules[1].to_json()
         elif isinstance(self.schedule, RecurringSchedule):

--- a/pyschlage/code.py
+++ b/pyschlage/code.py
@@ -20,6 +20,9 @@ _MAX_HOUR = 23
 _MAX_MINUTE = 59
 _ALL_DAYS = "7F"
 
+@dataclass
+class MultiSchedule:
+    schedules: list[RecurringSchedule]
 
 @dataclass
 class TemporarySchedule:
@@ -152,7 +155,7 @@ class AccessCode(Mutable):
     code: str = ""
     """The access code."""
 
-    schedule: TemporarySchedule | RecurringSchedule | None = None
+    schedule: MultiSchedule | TemporarySchedule | RecurringSchedule | None = None
     """Optional schedule at which the code is enabled."""
 
     notify_on_use: bool = False
@@ -194,9 +197,18 @@ class AccessCode(Mutable):
 
         :meta private:
         """
-        schedule: TemporarySchedule | RecurringSchedule | None = None
+        schedule: MultiSchedule | TemporarySchedule | RecurringSchedule | None = None
         if json["activationSecs"] == _MIN_TIME and json["expirationSecs"] == _MAX_TIME:
-            schedule = RecurringSchedule.from_json(json["schedule1"])
+            if "schedule2" in json:
+                schedules = []
+                #
+                for schedule_json in [json["schedule1"], json["schedule2"]]:
+                    sub_schedule = RecurringSchedule.from_json(schedule_json)
+                    if sub_schedule is not None:
+                        schedules.append(sub_schedule)
+                schedule = MultiSchedule(schedules)
+            else:
+                schedule = RecurringSchedule.from_json(json["schedule1"])
         else:
             schedule = TemporarySchedule.from_json(json)
 
@@ -232,7 +244,10 @@ class AccessCode(Mutable):
         }
         if self.access_code_id:
             json["accesscodeId"] = self.access_code_id
-        if isinstance(self.schedule, RecurringSchedule):
+        if isinstance(self.schedule, MultiSchedule):
+            json["schedule1"] = self.schedule.schedules[0].to_json()
+            json["schedule2"] = self.schedule.schedules[1].to_json()
+        elif isinstance(self.schedule, RecurringSchedule):
             json["schedule1"] = self.schedule.to_json()
         elif self.schedule is not None:
             json.update(self.schedule.to_json())

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -42,7 +42,7 @@ class TestAccessCode:
         access_code_id = "__access_code_uuid__"
         sched1 = RecurringSchedule(days_of_week=DaysOfWeek(mon=False))
         sched2 = RecurringSchedule(days_of_week=DaysOfWeek(tue=False))
-        sched = MultiRecurringSchedule([sched1, sched2])
+        sched = MultiRecurringSchedule(sched1, sched2)
         json = deepcopy(access_code_json)
         json["schedule1"] = sched1.to_json()
         json["schedule2"] = sched2.to_json()

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, call, create_autospec
 
 import pytest
 
-from pyschlage.code import AccessCode, DaysOfWeek, RecurringSchedule, TemporarySchedule
+from pyschlage.code import AccessCode, DaysOfWeek, MultiSchedule, RecurringSchedule, TemporarySchedule
 from pyschlage.device import Device
 from pyschlage.exceptions import NotAuthenticatedError
 from pyschlage.notification import Notification
@@ -35,6 +35,36 @@ class TestAccessCode:
         # it appears to always be 0 when returned by the API.
         access_code_json.pop("notification")
         assert to_json == access_code_json
+
+    def test_to_from_json_multi_schedule(
+        self, mock_auth: Mock, access_code_json: dict[str, Any], wifi_device: Device
+    ):
+        access_code_id = "__access_code_uuid__"
+        sched1 = RecurringSchedule(days_of_week=DaysOfWeek(mon=False))
+        sched2 = RecurringSchedule(days_of_week=DaysOfWeek(tue=False))
+        sched = MultiSchedule([sched1, sched2])
+        json = deepcopy(access_code_json)
+        json["schedule1"] = sched1.to_json()
+        json["schedule2"] = sched2.to_json()
+        code = AccessCode(
+            _auth=mock_auth,
+            _json=json,
+            _device=wifi_device,
+            name="Access code name",
+            code="0123",
+            schedule=sched,
+            device_id=wifi_device.device_id,
+            access_code_id=access_code_id,
+        )
+        assert AccessCode.from_json(mock_auth, json, wifi_device) == code
+        to_json = code.to_json()
+        # Access codes returned by the API don't have the `notificationEnabled`` property, but
+        # we need to pass it when saving an access code.
+        assert to_json.pop("notificationEnabled") == 0
+        # We also don't pass the `notification` property when saving an access code, but
+        # it appears to always be 0 when returned by the API.
+        json.pop("notification")
+        assert to_json == json
 
     def test_to_from_json_recurring_schedule(
         self, mock_auth: Mock, access_code_json: dict[str, Any], wifi_device: Device

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, call, create_autospec
 
 import pytest
 
-from pyschlage.code import AccessCode, DaysOfWeek, MultiSchedule, RecurringSchedule, TemporarySchedule
+from pyschlage.code import AccessCode, DaysOfWeek, MultiRecurringSchedule, RecurringSchedule, TemporarySchedule
 from pyschlage.device import Device
 from pyschlage.exceptions import NotAuthenticatedError
 from pyschlage.notification import Notification
@@ -42,7 +42,7 @@ class TestAccessCode:
         access_code_id = "__access_code_uuid__"
         sched1 = RecurringSchedule(days_of_week=DaysOfWeek(mon=False))
         sched2 = RecurringSchedule(days_of_week=DaysOfWeek(tue=False))
-        sched = MultiSchedule([sched1, sched2])
+        sched = MultiRecurringSchedule([sched1, sched2])
         json = deepcopy(access_code_json)
         json["schedule1"] = sched1.to_json()
         json["schedule2"] = sched2.to_json()


### PR DESCRIPTION
For Schlage Encode Plus Wifi locks, it is possible to set up to 2 recurring schedules at the same time, for the same access code.
<img src="https://github.com/user-attachments/assets/71bd20fa-bc1a-4907-92b3-ba4c09df01c1" width="400">
<img src="https://github.com/user-attachments/assets/8877f969-b8d8-4bf4-8845-084abb4a0484" width="400">

This PR adds a new schedule data class  `MultiRecurringSchedule` which simply stores a list of `RecurringSchedule` objects.


Selfishly looking to get this included, and a new release cut, so I can pull in the fixes to `notify_on_use` into the homeassistant integration. The existing release still has the bug where notify_on_use is always false.