### PR TITLE
fix(code): Return timezone-aware UTC datetimes from TemporarySchedule

### DIFF
--- a/pyschlage/code.py
+++ b/pyschlage/code.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import astuple, dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from .auth import Auth
@@ -48,8 +48,8 @@ class TemporarySchedule:
         :meta private:
         """
         return TemporarySchedule(
-            start=datetime.fromtimestamp(json["activationSecs"]),
-            end=datetime.fromtimestamp(json["expirationSecs"]),
+            start=datetime.fromtimestamp(json["activationSecs"], tz=UTC),
+            end=datetime.fromtimestamp(json["expirationSecs"], tz=UTC),
         )
 
     def to_json(self) -> dict:

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import Mock, call, create_autospec
 
@@ -100,8 +100,8 @@ class TestAccessCode:
     ):
         access_code_id = "__access_code_uuid__"
         sched = TemporarySchedule(
-            start=datetime(2022, 12, 25, 8, 30, 0),
-            end=datetime(2022, 12, 25, 9, 0, 0),
+            start=datetime(2022, 12, 25, 8, 30, 0, tzinfo=UTC),
+            end=datetime(2022, 12, 25, 9, 0, 0, tzinfo=UTC),
         )
         json = deepcopy(access_code_json)
         json["activationSecs"] = 1671957000


### PR DESCRIPTION
Fixes #355

Previously, `TemporarySchedule.from_json()` used `datetime.fromtimestamp()` without a timezone argument, which converts the Unix timestamp to the **local timezone** of the host as a **naive datetime**. This could lead to confusing results when the server's timezone differs from the user's expected timezone.

Now, datetimes are returned as timezone-aware UTC datetimes, which are unambiguous and consistent with the rest of the library (e.g. `Notification` already uses UTC-aware datetimes via `fromisoformat`).

### Changes
- `TemporarySchedule.from_json()`: pass `tz=UTC` to `datetime.fromtimestamp()`
- Updated test to use UTC-aware expected datetimes