### PR TITLE
fix(lock): Preserve access_codes across refresh() calls

### DIFF
--- a/pyschlage/lock.py
+++ b/pyschlage/lock.py
@@ -204,15 +204,20 @@ class Lock(Device):
         """Refreshes the Lock state.
 
         :param include_access_codes: Whether to also refresh access codes.
+            If False and access codes were previously fetched, they will be
+            preserved from the last refresh.
         :raise pyschlage.exceptions.NotAuthorizedError: When authentication fails.
         :raise pyschlage.exceptions.UnknownError: On other errors.
         """
         if not self._auth:
             raise NotAuthenticatedError
         path = self.request_path(self.device_id)
+        prev_access_codes = self.access_codes
         self._update_with(self._auth.request("get", path).json())
         if include_access_codes:
             self.refresh_access_codes()
+        elif prev_access_codes is not None:
+            self.access_codes = prev_access_codes
 
     def _put_attributes(self, attributes):
         if not self._auth:

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -162,6 +162,51 @@ class TestLock:
         mock_auth.request.assert_has_calls([call("get", "devices/__wifi_uuid__")])
         assert lock.name == "<NAME>"
 
+    def test_refresh_preserves_access_codes(
+        self,
+        mock_auth: Mock,
+        lock_json: dict[str, Any],
+        access_code_json: dict[str, Any],
+        notification_json: dict[str, Any],
+        access_code: AccessCode,
+    ) -> None:
+        """Regression test for https://github.com/dknowles2/pyschlage/issues/303.
+
+        refresh() without include_access_codes=True should preserve any
+        previously fetched access codes rather than clearing them.
+        """
+        lock = Lock.from_json(mock_auth, lock_json)
+        assert access_code.access_code_id is not None
+        lock.access_codes = {access_code.access_code_id: access_code}
+
+        lock_json["name"] = "<NAME>"
+        mock_auth.request.side_effect = [
+            Mock(json=Mock(return_value=lock_json)),
+        ]
+        lock.refresh(include_access_codes=False)
+
+        assert lock.name == "<NAME>"
+        assert lock.access_codes == {access_code.access_code_id: access_code}
+
+    def test_refresh_clears_access_codes_when_not_previously_fetched(
+        self,
+        mock_auth: Mock,
+        lock_json: dict[str, Any],
+        access_code_json: dict[str, Any],
+    ) -> None:
+        """Access codes should remain None when they were never fetched."""
+        lock = Lock.from_json(mock_auth, lock_json)
+        assert lock.access_codes is None
+
+        lock_json["name"] = "<NAME>"
+        mock_auth.request.side_effect = [
+            Mock(json=Mock(return_value=lock_json)),
+        ]
+        lock.refresh(include_access_codes=False)
+
+        assert lock.name == "<NAME>"
+        assert lock.access_codes is None
+
     def test_refresh_with_access_codes(
         self,
         mock_auth: Mock,


### PR DESCRIPTION
Fixes #303

Previously, calling `refresh()` without `include_access_codes=True` would always overwrite the `access_codes` attribute with `None` (the default from `from_json()`). This meant that if you initially fetched access codes and then periodically called `refresh()` to update lock state, the access codes would be silently lost.

### Root Cause

`refresh()` calls `_update_with()`, which constructs a new `Lock` via `from_json()` and copies all fields. Since `from_json()` doesn't populate `access_codes`, it is always `None` after construction — this value overwrites any previously-fetched access codes.

### Fix

Before calling `_update_with()`, we save the current `access_codes`. After the update, if `include_access_codes=False` **and** access codes were previously fetched (i.e., `access_codes is not None`), we restore them.

### Example

```python
# Fetch lock with access codes initially
locks = s.locks(include_access_codes=True)
lock = locks[0]
print(lock.access_codes)  # populated

# Later, refresh just the lock state (without re-fetching codes)
lock.refresh()  # include_access_codes=False by default
print(lock.access_codes)  # previously: None — now: still populated!
```