### PR TITLE
docs: fix undefined variable in README usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ print(locks[0].name)
 "My lock"
 
 # Lock the first lock.
-lock[0].lock()
+locks[0].lock()
 ```
 
 ## Installation


### PR DESCRIPTION
The locking example in the README referenced `lock[0].lock()`, but the variable defined earlier in the snippet is `locks` (plural). Copy-pasting the example as-is would raise a `NameError`.

## Changes
- `README.md`: `lock[0].lock()` → `locks[0].lock()`