### PR TITLE
style: apply Black/isort formatting to code.py

### DIFF
--- a/pyschlage/code.py
+++ b/pyschlage/code.py
@@ -20,6 +20,7 @@ _MAX_HOUR = 23
 _MAX_MINUTE = 59
 _ALL_DAYS = "7F"
 
+
 @dataclass
 class MultiRecurringSchedule:
     """A schedule consisting of at most two recurring schedules."""
@@ -30,6 +31,7 @@ class MultiRecurringSchedule:
     def __post_init__(self):
         if self.schedule1 is None and self.schedule2 is not None:
             raise ValueError("schedule1 must be set for schedule2 to be settable.")
+
 
 @dataclass
 class TemporarySchedule:
@@ -162,7 +164,9 @@ class AccessCode(Mutable):
     code: str = ""
     """The access code."""
 
-    schedule: MultiRecurringSchedule | TemporarySchedule | RecurringSchedule | None = None
+    schedule: MultiRecurringSchedule | TemporarySchedule | RecurringSchedule | None = (
+        None
+    )
     """Optional schedule at which the code is enabled."""
 
     notify_on_use: bool = False
@@ -204,12 +208,14 @@ class AccessCode(Mutable):
 
         :meta private:
         """
-        schedule: MultiRecurringSchedule | TemporarySchedule | RecurringSchedule | None = None
+        schedule: (
+            MultiRecurringSchedule | TemporarySchedule | RecurringSchedule | None
+        ) = None
         if json["activationSecs"] == _MIN_TIME and json["expirationSecs"] == _MAX_TIME:
             if "schedule2" in json:
                 schedule = MultiRecurringSchedule(
                     RecurringSchedule.from_json(json["schedule1"]),
-                    RecurringSchedule.from_json(json["schedule2"])
+                    RecurringSchedule.from_json(json["schedule2"]),
                 )
             else:
                 schedule = RecurringSchedule.from_json(json["schedule1"])

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -5,7 +5,13 @@ from unittest.mock import Mock, call, create_autospec
 
 import pytest
 
-from pyschlage.code import AccessCode, DaysOfWeek, MultiRecurringSchedule, RecurringSchedule, TemporarySchedule
+from pyschlage.code import (
+    AccessCode,
+    DaysOfWeek,
+    MultiRecurringSchedule,
+    RecurringSchedule,
+    TemporarySchedule,
+)
 from pyschlage.device import Device
 from pyschlage.exceptions import NotAuthenticatedError
 from pyschlage.notification import Notification


### PR DESCRIPTION
`pyschlage/code.py` and `tests/test_code.py` drifted from the project's Black/isort formatting after #369 (Multi-recurring schedule support) landed without going through `pre-commit`. This is a pure formatting fix — no behavior change.

## Changes
- Reformat `pyschlage/code.py` and `tests/test_code.py` per Black + isort (project defaults).