### PR TITLE
fix(log): return timezone-aware UTC datetimes from LockLog

### DIFF
--- a/pyschlage/common.py
+++ b/pyschlage/common.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from abc import abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass, field, fields
-from datetime import UTC, datetime
+from datetime import datetime
 from threading import Lock as Mutex
-from time import mktime
 from typing import Any
 
 from .auth import Auth
@@ -43,15 +42,6 @@ class Mutable:
         with self._mu:
             for f in fields(new_obj):
                 setattr(self, f.name, getattr(new_obj, f.name))
-
-
-def utc2local(utc: datetime) -> datetime:
-    """Converts a UTC datetime to localtime."""
-    epoch = mktime(utc.timetuple())
-    offset = datetime.fromtimestamp(epoch) - datetime.fromtimestamp(epoch, UTC).replace(
-        tzinfo=None
-    )
-    return (utc + offset).replace(tzinfo=None)
 
 
 def fromisoformat(dt: str) -> datetime:

--- a/pyschlage/log.py
+++ b/pyschlage/log.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 
-from .common import fromisoformat, utc2local
+from .common import fromisoformat
 
 _DEFAULT_UUID = "ffffffff-ffff-ffff-ffff-ffffffffffff"
 LOG_EVENT_TYPES = {
@@ -62,7 +62,7 @@ class LockLog:
     """A lock log entry."""
 
     created_at: datetime
-    """The time at which the log entry was created."""
+    """The UTC time at which the log entry was created."""
 
     message: str
     """The human-readable message associated with the log entry."""
@@ -92,7 +92,7 @@ class LockLog:
             return None if attr == _DEFAULT_UUID else attr
 
         return cls(
-            created_at=utc2local(fromisoformat(json["createdAt"])),
+            created_at=fromisoformat(json["createdAt"]),
             accessor_id=none_if_default(json["message"]["accessorUuid"]),
             access_code_id=none_if_default(json["message"]["keypadUuid"]),
             message=LOG_EVENT_TYPES.get(json["message"]["eventCode"], "Unknown"),

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from pyschlage.log import LockLog
 
@@ -9,7 +9,7 @@ class TestFromJson:
     def test_unlocked_by_thumbturn(self, log_json):
         log_json["message"]["eventCode"] = 4
         lock_log = LockLog(
-            created_at=datetime(2023, 3, 1, 17, 26, 47, 366000),
+            created_at=datetime(2023, 3, 1, 17, 26, 47, 366000, tzinfo=UTC),
             accessor_id=None,
             access_code_id=None,
             message="Unlocked by thumbturn",
@@ -24,7 +24,7 @@ class TestFromJson:
             }
         )
         lock_log = LockLog(
-            created_at=datetime(2023, 3, 1, 17, 26, 47, 366000),
+            created_at=datetime(2023, 3, 1, 17, 26, 47, 366000, tzinfo=UTC),
             accessor_id=None,
             access_code_id="__access-code-id__",
             message="Unlocked by keypad",
@@ -39,7 +39,7 @@ class TestFromJson:
             }
         )
         lock_log = LockLog(
-            created_at=datetime(2023, 3, 1, 17, 26, 47, 366000),
+            created_at=datetime(2023, 3, 1, 17, 26, 47, 366000, tzinfo=UTC),
             accessor_id="__user-id__",
             access_code_id=None,
             message="Unlocked by mobile device",


### PR DESCRIPTION
`LockLog.created_at` went through `utc2local()`, which converts to the host machine's local timezone and returns a **naive** datetime. This is inconsistent with the rest of the library — `Notification` and `TemporarySchedule` (#405) both return timezone-aware UTC datetimes — and made the value depend on wherever the code happens to run. It's also what caused `tests/test_log.py` to only pass when the test process's local timezone happened to be UTC (as it is on the GitHub Actions runners, by luck rather than by design).

## Changes
- `pyschlage/log.py`: `LockLog.created_at` is now built directly from `fromisoformat()` (UTC-aware), no longer converted to naive local time.
- `pyschlage/common.py`: removed `utc2local()`, which has no remaining callers.
- `tests/test_log.py`: updated expected `datetime`s to be UTC-aware; the tests are now correct regardless of the host's timezone (verified locally under `America/New_York`, `Asia/Kolkata`, and `Pacific/Auckland`).

## Compatibility note
This changes `LockLog.created_at` from a naive local-time `datetime` to a timezone-aware UTC `datetime`. Code that mixes it with naive datetimes (e.g. `datetime.now() - log.created_at`) will need to switch to `datetime.now(UTC)` or call `.astimezone()`/`.replace(tzinfo=None)` on the value. Flagging as `breaking` in addition to `bug` for that reason, even though the closely related #405 (same fix for `TemporarySchedule`) was labeled `bug` only.