### PR TITLE
ci: migrate formatting from Black/isort to ruff format

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -13,7 +13,6 @@
             "extensions": [
                 "charliermarsh.ruff",
                 "github.vscode-pull-request-github",
-                "ms-python.black-formatter",
                 "ms-python.mypy-type-checker",
                 "ms-python.python",
                 "ms-python.vscode-pylance",
@@ -25,8 +24,9 @@
                 "editor.tabSize": 4,
                 "python.pythonPath": "/usr/bin/python3",
                 "python.analysis.autoSearchPaths": false,
-                "python.formatting.provider": "black",
-                "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+                "[python]": {
+                    "editor.defaultFormatter": "charliermarsh.ruff"
+                },
                 "editor.formatOnPaste": false,
                 "editor.formatOnSave": true,
                 "editor.formatOnType": true,

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,9 +46,12 @@ jobs:
       run: |
         python -m pip install uv
         uv sync --group test
-    - name: Run ruff
+    - name: Run ruff check
       run: |
         uv run ruff check --output-format=github .
+    - name: Run ruff format
+      run: |
+        uv run ruff format --check --diff .
   mypy:
     runs-on: ubuntu-latest
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,18 +5,6 @@ repos:
       - id: pyupgrade
         args: [--py310-plus]
         stages: [manual]
-  - repo: https://github.com/psf/black
-    rev: 25.1.0
-    hooks:
-      - id: black
-        args:
-          - --quiet
-        files: ^.*\.py$
-  - repo: https://github.com/PyCQA/isort
-    rev: 6.0.1
-    hooks:
-      - id: isort
-        args: ["--profile", "black", "--filter-files"]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
@@ -41,9 +29,10 @@ repos:
           - --force
           - --keep-updates
         files: ^.*\.py$
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.11.13
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.22
     hooks:
-      - id: ruff
+      - id: ruff-check
         args:
           - --fix
+      - id: ruff-format

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
-    "python.formatting.provider": "black",
+    "[python]": {
+        "editor.defaultFormatter": "charliermarsh.ruff"
+    },
     "python.pythonPath": "/usr/local/bin/python",
     "python.testing.pytestEnabled": true,
     "cSpell.words": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,9 @@ write_to = "pyschlage/_version.py"
 [tool.coverage.report]
 omit     = ["pyschlage/_version.py"]
 
-[tool.isort]
-profile                    = "black"
-combine_as_imports         = true
-force_sort_within_sections = true
-forced_separate            = ["tests"]
+[tool.ruff.lint]
+extend-select = ["I"]
+
+[tool.ruff.lint.isort]
+combine-as-imports         = true
+force-sort-within-sections = true

--- a/pyschlage/code.py
+++ b/pyschlage/code.py
@@ -20,6 +20,7 @@ _MAX_HOUR = 23
 _MAX_MINUTE = 59
 _ALL_DAYS = "7F"
 
+
 @dataclass
 class MultiRecurringSchedule:
     """A schedule consisting of at most two recurring schedules."""
@@ -30,6 +31,7 @@ class MultiRecurringSchedule:
     def __post_init__(self):
         if self.schedule1 is None and self.schedule2 is not None:
             raise ValueError("schedule1 must be set for schedule2 to be settable.")
+
 
 @dataclass
 class TemporarySchedule:
@@ -162,7 +164,9 @@ class AccessCode(Mutable):
     code: str = ""
     """The access code."""
 
-    schedule: MultiRecurringSchedule | TemporarySchedule | RecurringSchedule | None = None
+    schedule: MultiRecurringSchedule | TemporarySchedule | RecurringSchedule | None = (
+        None
+    )
     """Optional schedule at which the code is enabled."""
 
     notify_on_use: bool = False
@@ -204,12 +208,14 @@ class AccessCode(Mutable):
 
         :meta private:
         """
-        schedule: MultiRecurringSchedule | TemporarySchedule | RecurringSchedule | None = None
+        schedule: (
+            MultiRecurringSchedule | TemporarySchedule | RecurringSchedule | None
+        ) = None
         if json["activationSecs"] == _MIN_TIME and json["expirationSecs"] == _MAX_TIME:
             if "schedule2" in json:
                 schedule = MultiRecurringSchedule(
                     RecurringSchedule.from_json(json["schedule1"]),
-                    RecurringSchedule.from_json(json["schedule2"])
+                    RecurringSchedule.from_json(json["schedule2"]),
                 )
             else:
                 schedule = RecurringSchedule.from_json(json["schedule1"])

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -5,7 +5,13 @@ from unittest.mock import Mock, call, create_autospec
 
 import pytest
 
-from pyschlage.code import AccessCode, DaysOfWeek, MultiRecurringSchedule, RecurringSchedule, TemporarySchedule
+from pyschlage.code import (
+    AccessCode,
+    DaysOfWeek,
+    MultiRecurringSchedule,
+    RecurringSchedule,
+    TemporarySchedule,
+)
 from pyschlage.device import Device
 from pyschlage.exceptions import NotAuthenticatedError
 from pyschlage.notification import Notification


### PR DESCRIPTION
`ruff` is already a project dependency used for linting. `ruff format` is a drop-in, Black-compatible formatter, and ruff's `I` lint rule covers import sorting (isort's job), so this consolidates formatting onto the one tool already in use instead of running Black and isort alongside it.

## Changes
- `pyproject.toml`: replace `[tool.isort]` with `[tool.ruff.lint.isort]`, translating the equivalent settings (`combine-as-imports`, `force-sort-within-sections`). `forced_separate = ["tests"]` is dropped — no file in the repo imports from a `tests` package, so it was a no-op.
- `.pre-commit-config.yaml`: remove the `black` and `isort` hooks; bump `ruff-pre-commit` to `astral-sh/ruff-pre-commit@v0.15.22` (matching the `ruff` version already pinned in `pyproject.toml`) and add its `ruff-format` hook alongside the existing check hook (renamed from the legacy `ruff` id to `ruff-check`).
- `.github/workflows/build-and-test.yml`: add a `ruff format --check --diff` step to the existing `ruff` job. No separate CI job or dependency needed — `ruff check` already covers import order via the new `I` rule.
- `.vscode/settings.json`, `.devcontainer.json`: switch the default Python formatter from `ms-python.black-formatter` to the `ruff` extension (already installed in the devcontainer), so format-on-save matches CI instead of fighting it.
- `pyschlage/code.py`, `tests/test_code.py`: reformatted with `ruff format` to fix pre-existing formatting drift (unwrapped import line, missing blank lines around dataclasses) that had landed on `main` unformatted.

Verified locally: `ruff format --check`, `ruff check`, `mypy`, and the full test suite all pass.