### PR TITLE
docs: fix undefined variable in RTD usage example

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,7 +34,7 @@ Basic usage
     >>> print(locks[0].name)
     'My lock'
     >>> # Lock the first lock.
-    >>> lock[0].lock()
+    >>> locks[0].lock()
 
 
 Installation


### PR DESCRIPTION
## Summary
- `docs/index.rst`'s quickstart snippet referenced `lock[0].lock()`, but the variable defined earlier in the snippet is `locks` (plural). Copy-pasting the example as written would raise a `NameError`.
- The same bug was already fixed in README.md by #416, but `docs/index.rst` (which Read the Docs renders) was missed, so the two usage examples had drifted out of sync.

## Test plan
- [x] Visual diff review — single-line typo fix, no code changes.