### PR TITLE
docs: fill in gaps in the API reference

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -41,16 +41,25 @@ itself can fetch additional data such as
 .. autoclass:: pyschlage.lock.Lock
    :members:
    :undoc-members:
+   :inherited-members:
+
+.. autoclass:: pyschlage.lock.LockStateMetadata
+   :members:
+   :undoc-members:
 
 .. autoclass:: pyschlage.code.AccessCode
    :members:
    :undoc-members:
 
-.. autoclass:: pyschlage.code.TemporarySchedule
+.. autoclass:: pyschlage.code.RecurringSchedule
    :members:
    :undoc-members:
 
-.. autoclass:: pyschlage.code.RecurringSchedule
+.. autoclass:: pyschlage.code.MultiRecurringSchedule
+   :members:
+   :undoc-members:
+
+.. autoclass:: pyschlage.code.TemporarySchedule
    :members:
    :undoc-members:
 
@@ -59,6 +68,19 @@ itself can fetch additional data such as
    :undoc-members:
 
 .. autoclass:: pyschlage.log.LockLog
+   :members:
+   :undoc-members:
+
+
+Users
+-----
+
+The :class:`Schlage <pyschlage.Schlage>` object's
+:meth:`users() <pyschlage.Schlage.users>` method, as well as the
+:attr:`Lock.users <pyschlage.lock.Lock.users>` attribute, return
+:class:`User <pyschlage.user.User>` objects.
+
+.. autoclass:: pyschlage.user.User
    :members:
    :undoc-members:
 

--- a/pyschlage/code.py
+++ b/pyschlage/code.py
@@ -26,7 +26,13 @@ class MultiRecurringSchedule:
     """A schedule consisting of at most two recurring schedules."""
 
     schedule1: RecurringSchedule | None
+    """The first recurring schedule during which the access code is enabled."""
+
     schedule2: RecurringSchedule | None
+    """The second recurring schedule during which the access code is enabled.
+
+    May only be set if ``schedule1`` is also set.
+    """
 
     def __post_init__(self):
         if self.schedule1 is None and self.schedule2 is not None:


### PR DESCRIPTION
## Summary
- `docs/api.rst` was missing entries for three public types that are actually returned by the library: `pyschlage.user.User` (from `Schlage.users()` and `Lock.users`), `pyschlage.lock.LockStateMetadata` (`Lock.lock_state_metadata`), and `pyschlage.code.MultiRecurringSchedule` (`AccessCode.schedule`). Anyone consulting the reference for these attributes previously hit a dead end.
- `Lock`'s `autoclass` directive didn't set `:inherited-members:`, so `device_id`/`device_type` (inherited from the `Device` base class) never rendered — added.
- `MultiRecurringSchedule.schedule1`/`schedule2` had no field docstrings, so added them for consistency with the other schedule dataclasses and so the new autodoc entry isn't empty.

## Test plan
- [x] `uv run pytest` — 71 passed
- [x] `uv run mypy pyschlage` — no issues
- [x] `uv run ruff check pyschlage docs` — all checks passed
- [x] Built the docs locally with Sphinx and confirmed `User`, `LockStateMetadata`, `MultiRecurringSchedule`, and `Lock.device_id`/`device_type` all render in `api.html`