### PR TITLE
docs: improve docstring consistency for Notification and Lock setters

### DIFF
--- a/pyschlage/lock.py
+++ b/pyschlage/lock.py
@@ -398,16 +398,36 @@ class Lock(Device):
         code.save()
 
     def set_beeper(self, enabled: bool):
-        """Sets the beeper_enabled setting."""
+        """Sets the beeper_enabled setting.
+
+        :param enabled: Whether the keypress beep should be enabled.
+        :type enabled: bool
+        :raise pyschlage.exceptions.NotAuthorizedError: When authentication fails.
+        :raise pyschlage.exceptions.UnknownError: On other errors.
+        """
         self._put_attributes({"beeperEnabled": 1 if enabled else 0})
 
     def set_lock_and_leave(self, enabled: bool):
-        """Sets the lock_and_leave setting."""
+        """Sets the lock_and_leave setting.
+
+        :param enabled: Whether lock-and-leave should be enabled.
+        :type enabled: bool
+        :raise pyschlage.exceptions.NotAuthorizedError: When authentication fails.
+        :raise pyschlage.exceptions.UnknownError: On other errors.
+        """
         self._put_attributes({"lockAndLeaveEnabled": 1 if enabled else 0})
 
     def set_auto_lock_time(self, auto_lock_time: int):
         """Sets the auto_lock_time setting. Setting it to `0` turns off the
-        auto-lock feature."""
+        auto-lock feature.
+
+        :param auto_lock_time: Number of seconds of inactivity before the lock
+            automatically locks itself. Must be one of :data:`AUTO_LOCK_TIMES`.
+        :type auto_lock_time: int
+        :raise ValueError: When auto_lock_time is not one of :data:`AUTO_LOCK_TIMES`.
+        :raise pyschlage.exceptions.NotAuthorizedError: When authentication fails.
+        :raise pyschlage.exceptions.UnknownError: On other errors.
+        """
         if auto_lock_time not in AUTO_LOCK_TIMES:
             raise ValueError(f"auto_lock_time must be one of: {AUTO_LOCK_TIMES}")
         self._put_attributes({"autoLockTime": auto_lock_time})

--- a/pyschlage/notification.py
+++ b/pyschlage/notification.py
@@ -22,14 +22,32 @@ class Notification(Mutable):
     """A Schlage WiFi lock notification."""
 
     notification_id: str = ""
+    """Unique identifier for the notification."""
+
     user_id: str | None = None
+    """Unique identifier for the user this notification is scoped to."""
+
     device_id: str | None = None
+    """Unique identifier for the device this notification is scoped to."""
+
     device_type: str | None = None
+    """The device type of the device this notification is scoped to."""
+
     notification_type: str = UNKNOWN
+    """The kind of event this notification fires for, e.g. :data:`ON_UNLOCK_ACTION`."""
+
     active: bool = False
+    """Whether the notification is currently enabled."""
+
     filter_value: str | None = None
+    """Optional value used to further scope which events trigger the notification."""
+
     created_at: datetime | None = None
+    """The UTC time at which the notification was created."""
+
     updated_at: datetime | None = None
+    """The UTC time at which the notification was last updated."""
+
     _json: dict[str, Any] = field(default_factory=dict, repr=False)
 
     @staticmethod
@@ -45,6 +63,10 @@ class Notification(Mutable):
 
     @classmethod
     def from_json(cls, auth: Auth, json: dict[str, Any]) -> "Notification":
+        """Creates a Notification from a JSON dict.
+
+        :meta private:
+        """
         return Notification(
             _auth=auth,
             _json=json,


### PR DESCRIPTION
## Summary
- `Notification`'s dataclass fields had no docstrings at all, and `Notification.from_json()` was missing a docstring entirely — inconsistent with every other `Mutable` subclass in the codebase (`Lock`, `AccessCode`, `LockLog`, `User`, `Device`), which all document their fields. Added field docstrings and the missing `:meta private:` docstring on `from_json()` to match.
- `Lock.set_beeper`, `set_lock_and_leave`, and `set_auto_lock_time` were missing the `:param:`/`:raise:` documentation that sibling mutating methods (`lock`, `unlock`, `refresh`, `add_access_code`) already have, even though they can raise the same `NotAuthorizedError`/`UnknownError`.

No behavior changes — docstrings only.

## Test plan
- [x] `uv run pytest` — 71 passed
- [x] `uv run mypy pyschlage` — no issues
- [x] `uv run ruff check pyschlage` — all checks passed
- [x] `uv run ruff format --check pyschlage` — already formatted