### PR TITLE
ci: add Python 3.13 and 3.14 to the test matrix

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v7
     - name: "Set up Python ${{ matrix.python-version }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ keywords        = ["schlage", "api", "iot"]
 classifiers     = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 


### PR DESCRIPTION
## Summary
- Add Python 3.13 and 3.14 to the `build-and-test`, `ruff`, and `mypy` CI matrices
- Add corresponding trove classifiers to `pyproject.toml`

Both interpreters have been stable for well over a year (3.13 since Oct 2024, 3.14 since Oct 2025) but weren't tested or advertised as supported.

## Test plan
- [x] `uv run coverage run -m pytest` passes locally under 3.11, 3.12, 3.13, and 3.14
- [x] `uv run mypy .` passes under all four versions
- [x] `uv run ruff check .` / `ruff format --check` pass
- [x] CI will confirm on the new matrix entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)