### PR TITLE
chore: modernize pre-commit hook config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.20.0
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
-        args: [--py310-plus]
+        args: [--py311-plus]
         stages: [manual]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-executables-have-shebangs
         stages: [manual]
@@ -16,7 +16,7 @@ repos:
         args:
           - --branch=main
   - repo: https://github.com/cdce8p/python-typing-update
-    rev: v0.7.2
+    rev: v0.8.1
     hooks:
       # Run `python-typing-update` hook manually from time to time
       # to update python typing syntax.
@@ -25,12 +25,12 @@ repos:
       - id: python-typing-update
         stages: [manual]
         args:
-          - --py310-plus
+          - --py311-plus
           - --force
           - --keep-updates
         files: ^.*\.py$
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.22
+    rev: v0.16.0
     hooks:
       - id: ruff-check
         args:


### PR DESCRIPTION
## Summary
- Bump `pyupgrade`/`python-typing-update` target from `--py310-plus` to `--py311-plus`, matching `requires-python = ">=3.11"`
- Bump pinned hook revisions (pyupgrade, pre-commit-hooks, python-typing-update, ruff-pre-commit) to latest, keeping `ruff-pre-commit` in sync with the `ruff==0.16.0` pin in `pyproject.toml`

Dependabot doesn't track pre-commit hook revisions, so these had drifted.

## Test plan
- [x] `pre-commit run --all-files` (non-manual hooks) passes
- [x] `pre-commit run --hook-stage manual pyupgrade --all-files` passes with no changes needed
- [x] `pre-commit run --hook-stage manual python-typing-update --all-files` passes with no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)