### PR TITLE
test: wire up the pytest-timeout dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ readme          = { file = ["README.md"], content-type = "text/markdown" }
 [tool.setuptools_scm]
 write_to = "pyschlage/_version.py"
 
+[tool.pytest.ini_options]
+addopts = "--timeout=30"
+
 [tool.coverage.run]
 source = ["pyschlage"]
 


### PR DESCRIPTION
## Summary
- `pytest-timeout` has been a `test`-group dependency with zero configuration anywhere in the repo (no `addopts`, no `pytest.ini_options`, no per-test markers) — it was installed but never actually enforcing anything.
- Set a 30s per-test default via `[tool.pytest.ini_options] addopts = "--timeout=30"` as a safety net against hangs.

## Test plan
- [x] `uv run pytest --help` confirms `timeout: 30.0s` is active
- [x] `uv run coverage run -m pytest` — 71 passed
- [x] `uv run mypy .` / `ruff check` / `ruff format --check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)