### PR TITLE
chore: consolidate mypy config into pyproject.toml, add strictness

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,0 @@
-[mypy]
-
-[mypy-botocore.*]
-ignore_missing_imports = True
-
-[mypy-pycognito.*]
-ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,16 @@ source = ["pyschlage"]
 omit       = ["pyschlage/_version.py"]
 fail_under = 100
 
+[tool.mypy]
+check_untyped_defs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+strict_equality = true
+
+[[tool.mypy.overrides]]
+module = ["botocore.*", "pycognito.*"]
+ignore_missing_imports = true
+
 [tool.ruff.lint]
 extend-select = ["I"]
 


### PR DESCRIPTION
## Summary
- Fold `mypy.ini` into `pyproject.toml`'s `[tool.mypy]` (plus `[[tool.mypy.overrides]]` for the botocore/pycognito `ignore_missing_imports` rules) — one less config file
- Enable `check_untyped_defs`, `warn_redundant_casts`, `warn_unused_ignores`, `strict_equality`

The old `mypy.ini` had zero strictness flags beyond the two `ignore_missing_imports` overrides.

I deliberately did **not** enable `disallow_untyped_defs` (would require annotating ~150 mostly-test functions — too big a diff for a cleanup PR) or `warn_unreachable` (flags a false positive on this codebase's dataclass mutation pattern: mypy doesn't invalidate a narrowed `Optional` attribute across a `self.method()` call that reassigns it internally — confirmed with a minimal repro, not an actual bug).

## Test plan
- [x] `uv run mypy .` — clean, no issues
- [x] `uv run coverage run -m pytest` — 71 passed
- [x] `uv run ruff check .` / `ruff format --check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)