### PR TITLE
docs: derive Sphinx version and copyright year dynamically

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,14 +1,16 @@
 # Configuration file for the Sphinx documentation builder.
 
+import datetime
+from importlib.metadata import version as _pkg_version
 import os
 import sys
 
 sys.path.insert(0, os.path.abspath(".."))
 
 project = "pyschlage"
-copyright = "2023, David Knowles"
+copyright = f"{datetime.datetime.now(tz=datetime.UTC).year}, David Knowles"
 author = "David Knowles"
-release = "2023.3.2"
+release = _pkg_version("pyschlage")
 extensions = ["sphinx.ext.autodoc", "sphinx.ext.autosummary"]
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]


### PR DESCRIPTION
## Summary
- `docs/conf.py` hardcoded `release = "2023.3.2"` and `copyright = "2023, ..."` — three years stale
- `release` now comes from the installed package's metadata via `importlib.metadata.version("pyschlage")` (populated by setuptools_scm, same mechanism `.readthedocs.yaml`'s `pip install .` step already relies on)
- `copyright` year is computed at build time

## Test plan
- [x] Built the docs end-to-end in a clean venv (`pip install -e .` + `docs/requirements.txt`, then `sphinx-build`) — succeeded
- [x] Confirmed the built HTML shows the real current version (`2026.7.1.dev...`) in the title and `Copyright 2026` in the footer, instead of the frozen 2023 values
- [x] `ruff check` / `ruff format --check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)