### PR TITLE
ci: publish to PyPI via trusted publishing

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -8,22 +8,42 @@ env:
   PYTHON_VERSION: "3.12"
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # setuptools_scm needs full history and tags to derive the version.
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - name: Install dependencies
+      - name: Build distributions
         run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel twine build
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: |
+          python -m pip install --upgrade pip build
           python -m build
-          twine upload dist/*
+      - name: Upload distributions
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyschlage
+    permissions:
+      # Required for trusted publishing (OIDC) and attestations.
+      id-token: write
+      attestations: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.14.2


### PR DESCRIPTION
## Summary

Replaces the `twine` + long-lived `PYPI_TOKEN` publishing flow with PyPI trusted publishing (OIDC). GitHub mints a short-lived token per workflow run, so there is no API token to store or rotate.

## Changes

- Split `publish-python.yml` into separate `build` and `publish` jobs so `id-token: write` is scoped to the publish step alone.
- Publish with `pypa/gh-action-pypi-publish`, which also generates PEP 740 attestations for the uploaded distributions.
- Set `fetch-depth: 0` on checkout so `setuptools_scm` can reliably derive the version from tags.

## Follow-up

The trusted publisher is already registered on PyPI for this repository, workflow `publish-python.yml`, environment `pypi`. Once a release publishes successfully through the new workflow, the `PYPI_TOKEN` repository secret can be deleted.

## Testing

The workflow only runs on `release: published`, so it cannot be exercised by CI on this PR. The YAML parses and no references to `PYPI_TOKEN` or `twine` remain in the repository. The next release is the real verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)