### PR TITLE
Fix: redact nested identifiers in lockStateMetadata diagnostics

### DIFF
--- a/pyschlage/lock.py
+++ b/pyschlage/lock.py
@@ -169,7 +169,7 @@ class Lock(Device):
                 "attributes.keypadFirmwareVersion",
                 "attributes.lockAndLeaveEnabled",
                 "attributes.lockState",
-                "attributes.lockStateMetadata",
+                "attributes.lockStateMetadata.actionType",
                 "attributes.mainFirmwareVersion",
                 "attributes.mode",
                 "attributes.modelName",

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -106,10 +106,10 @@ class TestLock:
                 "lockAndLeaveEnabled": 1,
                 "lockState": 1,
                 "lockStateMetadata": {
-                    "UUID": None,
+                    "UUID": "<REDACTED>",
                     "actionType": "periodicDeepQuery",
-                    "clientId": None,
-                    "name": None,
+                    "clientId": "<REDACTED>",
+                    "name": "<REDACTED>",
                 },
                 "macAddress": "<REDACTED>",
                 "mainFirmwareVersion": "10.00.00264232",


### PR DESCRIPTION
`Lock.get_diagnostics()` allow-listed `attributes.lockStateMetadata` with no child paths. `redact()` treats a bare entry as a wildcard over the whole subtree, so the nested `UUID`, `clientId` and `name` fields were emitted verbatim — these can carry real device identifiers (serial numbers) even though the top-level `serialNumber` is redacted.

Narrowed the entry to `attributes.lockStateMetadata.actionType`, the only non-identifying member of that object. The other three now render as `<REDACTED>`.

Reported in home-assistant/core#178337: https://github.com/home-assistant/core/pull/178337/changes#r3853387479

Downstream: after a release, the Home Assistant diagnostics fixture needs updating to expect `<REDACTED>` for those keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)