### PR TITLE
Auto-bump CalVer month and year in release drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,6 +9,28 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
+      - name: Compute next CalVer version
+        id: calver
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # CalVer period for today, e.g. "2026.8" (month is not zero-padded).
+          period="$(date -u +'%Y.%-m')"
+          # Latest published release; this endpoint ignores drafts and prereleases.
+          latest="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name 2>/dev/null || true)"
+          if [[ "${latest}" == "${period}."* ]]; then
+            # Still in the same month: bump the patch component.
+            version="${period}.$(( ${latest##*.} + 1 ))"
+          else
+            # New month (or year): start the period over at patch 0.
+            version="${period}.0"
+          fi
+          echo "Latest release: ${latest:-<none>}; next version: ${version}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
       - uses: release-drafter/release-drafter@v7.7.0
+        with:
+          version: ${{ steps.calver.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Release Drafter's default resolver only bumps the semver patch component off the last tag, so the year and month components had to be updated by hand whenever a month rolled over.

Compute the version in the workflow instead: derive the CalVer period from the current date (`YYYY.M`, unpadded month), bump the patch when the latest published release is in the same period, and start at patch `0` otherwise. The result is passed to the action's `version` input, which overrides `$RESOLVED_VERSION` in the name and tag templates.

Verified cases:

| Latest release | Today's period | Next version |
| --- | --- | --- |
| `2026.8.0` | `2026.8` | `2026.8.1` |
| `2026.8.1` | `2026.9` | `2026.9.0` |
| `2026.12.3` | `2027.1` | `2027.1.0` |
| _none_ | `2026.8` | `2026.8.0` |

Notes:

- The `repos/.../releases/latest` endpoint ignores drafts, so re-running on each push to `main` does not compound the patch bump. It also ignores prereleases, so publishing one mid-period would make the next bump compute off the last non-prerelease tag.
- The draft is rewritten on every push to `main`, so its title and tag always track the current date. A draft cut in August but published in September gets `2026.9.0` rather than `2026.8.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)